### PR TITLE
Add aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ setuptools.setup(
     author="Bryan Blunt",
     author_email="bryan@blunt.me.uk",
     description="Controls for Lightwave RF second generation devices",
+    install_requires=[
+        "aiohttp<=4",
+    ],
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/bigbadblunt/lightwave2",


### PR DESCRIPTION
`aiohttp` is a [runtime requirement](https://github.com/bigbadblunt/lightwave2/blob/master/lightwave2/lightwave2.py#L5).