### PR TITLE
Device naming and others

### DIFF
--- a/lightwave2/lightwave2.py
+++ b/lightwave2/lightwave2.py
@@ -514,8 +514,6 @@ class LWLink2:
 
     def get_featuresets(self, featuresets, devices, features):
         for y in featuresets:
-            _LOGGER.warning("async_get_hierarchy: Creating device {}".format(y))
-
             new_featureset = LWRFFeatureSet()
             new_featureset.link = self
             new_featureset.featureset_id = y["groupId"]
@@ -621,7 +619,7 @@ class LWLink2Public(LWLink2):
                     new_featureset.link = self
                     new_featureset.featureset_id = y["featureSetId"]
                     new_featureset.product_code = x["productCode"]
-                    new_featureset.name = x["name"]
+                    new_featureset.name = y["name"]
 
                     for z in y["features"]:
                         _LOGGER.debug("async_get_hierarchy: Adding device features {}".format(z))

--- a/lightwave2/lightwave2.py
+++ b/lightwave2/lightwave2.py
@@ -88,7 +88,7 @@ class LWRFFeature:
 
 class LWLink2:
 
-    def __init__(self, username=None, password=None, auth_method="username", api_token=None, refresh_token=None):
+    def __init__(self, username=None, password=None, auth_method="username", api_token=None, refresh_token=None, device_id=None):
 
         self.featuresets = {}
         self._authtoken = None
@@ -106,7 +106,7 @@ class LWLink2:
         self._callback = []
 
         # Websocket only variables:
-        self._device_id = str(uuid.uuid4())
+        self._device_id = (device_id or "PLW2:") + str(uuid.uuid4())
         self._websocket = None
 
         self._group_ids = []

--- a/lightwave2/lightwave2.py
+++ b/lightwave2/lightwave2.py
@@ -188,12 +188,17 @@ class LWLink2:
                             feature_id = message["items"][0]["payload"]["featureId"]
                             feature = self.get_feature_by_featureid(feature_id)
                             value = message["items"][0]["payload"]["value"]
-                            prev_value = feature.state
-                            feature._state = value
-                            cblist = [c.__name__ for c in self._callback]
-                            _LOGGER.debug("consumer_handler: Event received (%s %s %s), calling callbacks %s", feature_id, feature, value, cblist)
-                            for func in self._callback:
-                                func(feature=feature.name, feature_id=feature.id, prev_value = prev_value, new_value = value)
+                            
+                            if feature is None:
+                                _LOGGER.debug("consumer_handler: feature is None: %s)", feature_id)
+                            else:
+                                prev_value = feature.state
+
+                                feature._state = value
+                                cblist = [c.__name__ for c in self._callback]
+                                _LOGGER.debug("consumer_handler: Event received (%s %s %s), calling callbacks %s", feature_id, feature, value, cblist)
+                                for func in self._callback:
+                                    func(feature=feature.name, feature_id=feature.id, prev_value = prev_value, new_value = value)
                         else:
                             _LOGGER.warning("consumer_handler: Unhandled event message: %s", message)
                     else:


### PR DESCRIPTION
- line 91/109: add default identification string "PLW2" via device_id to the websocket connection
- line 192+: protect against receiving events before featureSets are built
- line 241+: change to using group.hierarchy for discovery 
   - new functions lines 514 - 542
- change to using featureSet name instead of feature.name
- line 627: when publicApi, use featureSet name for device